### PR TITLE
Support for list types, behavior on multiple same options, better docs. This pull request contains three contributions.  I know I should in principle create three separate pull requests for three different contributions but I am so lazy that I didn't decompose it into three (it takes some time...).  Please let me know if you feel it should be three separate pull reqs, especially when you might accept only a part of the patches, not the whole. I know this pull-req does not confirm to the normal convention for pull requests in several ways, so anyway I would squash or make whatever changes to the commits if needed. I'll explain the three contributions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # optparse-declarative
 
-`optparse-declarative` is a declarative and easy to use command-line option parser.
+`optparse-declarative` is a declarative and easy-to-use command-line option parser.
 
 # Install
 
@@ -12,15 +12,17 @@ $ cabal install optparse-declarative
 
 ## Writing a simple command
 
-First, you need to enable `DataKinds` extension and import `Options.Declarative` module.
+First, you need to enable `DataKinds` extension. Then import `Options.Declarative` module.
 
 ```hs
 {-# LANGUAGE DataKinds #-}
 import           Options.Declarative
 ```
 
-Then, define the command line option as a **type of the function**.
-For example, this is a simple greeting program:
+Next, define command line options as a **type of the function**.
+For example, this is a simple greeting program with `-g` option that
+takes a message of type `String` and an unnamed command-line argument
+that specifies a name:
 
 ```hs
 greet :: Flag "g" '["greet"] "STRING" "greeting message" (Def "Hello" String)
@@ -30,26 +32,47 @@ greet msg name =
     liftIO $ putStrLn $ get msg ++ ", " ++ get name ++ "!"
 ```
 
-There are two type of options, `Flag` and `Arg`.
-`Flag` is named argument and `Arg` is unnamed argument.
-Last argument of both options is value type.
-If you need to specify default value, use the modifiers such as `Def`.
+There are two types of options, `Flag` and `Arg`.
+`Flag` represents a named argument (e.g., `--greet "Hola"`), and `Arg` an unnamed argument (e.g., `John` of `greet --greet Hola John`).
+The last argument of `Flag` and `Arg` is the type of the value of the
+argument; in this example, they are both `String`.
+You can specify any type for the value as long as the type is an
+instance of `ArgRead` typeclass, in which the conversion function
+from `String` to the specified type is defined.
+`Options.Declarative` provides following instances of `ArgRead`
+typeclass.
 
-In above, variable `msg` has a very complex type (`Flag "g" '["greet"] "STRING" "greeting message" (Def "Hello" String)`).
-In order to get the value of usual type (in this case, that is `String`),
+- Int
+- Integer
+- Bool
+- Double
+- String
+- (ArgRead a) => Maybe a
+
+Users can add a new instance of `ArgRead` to support any user-defined type.
+Please see Section "How to add a new instance of `ArgRead`" for details.
+
+If you wish to specify a default value for allowing users to omit a
+value, use the modifier `Def` with the default value as the second type argument (and the third type argument is the type of the value).
+You need to specify the default value in `String` instead of the final
+value of the target type; the string will be converted to the final
+value via `ArgRead` typeclass.
+
+In the example above, the variable `msg` has a very complex type (`Flag "g" '["greet"] "STRING" "greeting message" (Def "Hello" String)`).
+In order to get the value of the target type (in this case, that is `String`),
 you can use `get` function.
 
 The whole type of command is `Cmd`.
 `Cmd` is an instance of `MonadIO` and it has some extra information.
 
-After defining a command, you just invoke it by `run_`.
+Finally, you can run the whole program by `run_`.
 
 ```hs
 main :: IO ()
 main = run_ greet
 ```
 
-You can execute this program like this:
+Here is an example session with the program shown above.
 
 ```bash
 $ ghc simple.hs
@@ -71,13 +94,50 @@ $ ./simple --greet=Goodbye World
 Goodbye, World!
 ```
 
-## Writing multiple sum-commands
+Note that only the final option is used when multiple options of the
+same name are given. This behavior emulates the behavior of a naive
+program that uses GNU Getopt.
 
-You can write (nested) sub-commands.
+```bash
+$ ./simple --greet=Hello --greet=Goodbye World
+Goodbye, World!
+```
 
-Just groupe subcommands by `Group`, you got sub-command parser.
+There is another way of interpreting multiple options of the same name.
+Suppose if you need to get multiple values from the same option.
+Say, you wish to get `["Hello", "Goodbye"]` from the command-line
+option `--greet=Hello --greeet=Goodbye`. Then, you can use
+the modifier `List` to indicate that it accepts multiple values.
+The first line of the function `greet` in the example above
+would be changed as this:
 
-This is the example:
+```hs
+greet :: Flag "g" '["greet"] "STRING" "greeting message" (List String)
+```
+
+The value returned by `get` will be a value of type `[String]`.
+See the complete working example at `example/list.hs` for details.
+
+The reason why we did not use `[String]` for specifying multiple
+values was that it is hard to tell apart `String` from a list of
+`Char` because `String` a type synonym of `[Char]`. If we only
+allow other string types such as `Text` and drop the support for
+`String`, we would be able to allow notations such as `[Text]` or
+`[Int]`.
+
+
+## Writing multiple subcommands
+
+You can write (nested) subcommands.
+You don't know what subcommands are? Imagine `git` command.
+`git` has subcommands such as `git add`, `git commit`, `git log`, etc.
+`git` has nested subcommands such as `git remote add`, `git remote rm`,
+etc.
+`optparse-declarative` provides an easy way to provide such possibly
+nested subcommands.
+
+Just group subcommands by `Group`, then you get a subcommand parser.
+Here is an example with two subcommands `greet` and `connect`:
 
 ```hs
 {-# LANGUAGE DataKinds #-}
@@ -108,7 +168,7 @@ connect host port = do
     liftIO $ putStrLn $ "connect to " ++ addr
 ```
 
-And this is the output:
+This is a sample session for the program above:
 
 ```bash
 $ ./subcmd --help
@@ -124,4 +184,79 @@ $ ./subcmd connect --port=1234
 connect to localhost:1234
 ```
 
+If you wish to specify the program name or the version number,
+use `run` instead of `run_`. The first argument of `run` is
+a program name (of type `String`). The second argument is
+a version number (of type `Maybe String`).
+
+```hs
+main :: IO ()
+main = run "program_name" (Just "1.3.2") $
+    Group "Test program for library"
+    [ subCmd "greet"   greet
+    , subCmd "connect" connect
+    ]
+```
+
 For more examples, please see `example` directory.
+
+
+## Default options
+`optparse-declarative` provides a few default options.
+For example, `--help` is defined automatically so users do not have to
+write it by their own. If run with `run` and the version number,
+`--version` is defined automatically. Also, `--verbosity` option (`-v`
+for short) is defined by default.
+`getVerbosity` returns the verbosity level in `Int`.
+`-v` gives 1, `-vv` gives 2, `-vvv` gives 3.
+Alternatively, `--verbose=3` would yield 3.
+
+
+## How to add a new instance of `ArgRead`
+Users need to create an instance of `ArgRead` for supporting a new type
+for the command line argument. Here is the definition of class
+`ArgRead`.
+
+```hs
+class ArgRead a where
+    -- | Type of the argument
+    type Unwrap a :: *
+    type Unwrap a = a
+
+    -- | Get the argument's value
+    unwrap :: a -> Unwrap a
+    default unwrap :: a ~ Unwrap a => a -> Unwrap a
+    unwrap = id
+
+    -- | Argument parser
+    argRead :: [String] -> Maybe a
+    default argRead :: Read a => [String] -> Maybe a
+    argRead ss = getLast $ mconcat $ Last . readMaybe <$> ss
+
+    -- | Indicate this argument is mandatory
+    needArg :: Proxy a -> Bool
+    needArg _ = True
+```
+
+Suppose you are adding a support for your type `T`.
+We explain which function to define explicitly, depending on the
+property of `T`.
+
+If `T` is the type of the final value you take out of a command line,
+you do not have to define `Unwrap`. If `T` is a wrapper like `Def` or
+`List`, define `type Unwrap T = <unwrapped type>`. For `Def x y`,
+`type Unwrap (Def x y) = y`, while `type Unwrap (List x) = [x]` for
+`List x`. If you defined `Unwrap`, define `unwrap` that takes
+an actual value out of the wrapped value.
+
+`argRead` is the main function that converts String into a value.
+If the type is an instance of `Read` and you are satisfied with
+how `read` converts a `String` into value, there is no need to
+define your own `argRead`. Otherwise, you define a function that
+converts a `String` into a value of the target type. When parsing
+is successful, return `Just`. When it fails, return `Nothing`.
+If the input is `[]`, it indicates the option does not have an
+argument; otherwise the input is a list of a single `String`.
+Last but not least, define `needArg _ = False` when the option
+allows us to omit the associated value; consider a boolean
+option like `--help`.

--- a/example/bool.hs
+++ b/example/bool.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE DataKinds #-}
+
+import           Control.Monad.Trans
+import           Options.Declarative
+
+bflag :: Flag "b" '["boolflag"] "STRING" "boolean flag" Bool
+      -> Cmd "Simple greeting example" ()
+bflag b =
+    liftIO $ putStrLn $ if get b then "Flag is True" else "Flag is False"
+
+main :: IO ()
+main = run_ bflag

--- a/example/list.hs
+++ b/example/list.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE DataKinds #-}
+
+import           Control.Monad
+import           Control.Monad.Trans
+import           Options.Declarative
+
+greet :: Flag "n" '["name"] "STRING" "name" (List String)
+      -> Cmd "Count the number of people" ()
+greet name =
+    let people_name_list = get name
+        num_people = length people_name_list
+    in liftIO $ do
+        putStrLn $ "There are " ++ show num_people ++ " people on the list."
+        putStrLn " -- "
+        forM_ people_name_list putStrLn
+
+main :: IO ()
+main = run_ greet

--- a/src/Options/Declarative.hs
+++ b/src/Options/Declarative.hs
@@ -32,6 +32,7 @@ module Options.Declarative (
     -- * Defining argment types
     ArgRead(..),
     Def,
+    List(..),
 
     -- * Subcommands support
     Group(..),
@@ -47,6 +48,7 @@ import           Control.Monad.Reader
 import           Control.Monad.Trans
 import           Data.List
 import           Data.Maybe
+import           Data.Monoid
 import           Data.Proxy
 import           GHC.TypeLits
 import           System.Console.GetOpt
@@ -54,6 +56,7 @@ import           System.Environment
 import           System.Exit
 import           System.IO
 import           Text.Read
+-- import           Debug.Trace
 
 -- | Command line option
 class Option a where
@@ -93,9 +96,9 @@ class ArgRead a where
     unwrap = id
 
     -- | Argument parser
-    argRead :: Maybe String -> Maybe a
-    default argRead :: Read a => Maybe String -> Maybe a
-    argRead s = readMaybe =<< s
+    argRead :: [String] -> Maybe a
+    default argRead :: Read a => [String] -> Maybe a
+    argRead ss = getLast $ mconcat $ Last . readMaybe <$> ss
 
     -- | Indicate this argument is mandatory
     needArg :: Proxy a -> Bool
@@ -108,18 +111,29 @@ instance ArgRead Integer
 instance ArgRead Double
 
 instance ArgRead String where
-    argRead = id
+    argRead [] = Nothing
+    argRead xs = Just $ head $ reverse xs
 
 instance ArgRead Bool where
-    argRead Nothing = Just False
-    argRead (Just "t") = Just True
+    argRead [] = Just False
+    argRead ["t"] = Just True
     argRead _ = Nothing
 
     needArg _ = False
 
 instance ArgRead a => ArgRead (Maybe a) where
-    argRead Nothing = Just Nothing
-    argRead (Just a) = Just <$> argRead (Just a)
+    argRead [] = Just Nothing
+    argRead xs = argRead xs
+
+newtype List a = List { getList :: [a] }
+
+instance ArgRead a => ArgRead (List a) where
+    type Unwrap (List a) = [a]
+    unwrap v = getList v
+    argRead xs = let vs = (argRead . (:[])) <$> xs
+                 in case [fromJust v | v <- vs, isJust v] of
+                    [] -> Nothing
+                    xs -> Just $ List xs
 
 -- | The argument which has defalut value
 newtype Def (defaultValue :: Symbol) a =
@@ -130,8 +144,10 @@ instance (KnownSymbol defaultValue, ArgRead a) => ArgRead (Def defaultValue a) w
     unwrap = unwrap . getDef
 
     argRead s =
-        let s' = fromMaybe (symbolVal (Proxy :: Proxy defaultValue)) s
-        in Def <$> argRead (Just s')
+        let s' = case s of
+                 [] -> [symbolVal (Proxy :: Proxy defaultValue)]
+                 v  -> v
+        in Def <$> argRead s'
 
 -- | Command
 newtype Cmd (help :: Symbol) a =
@@ -224,18 +240,17 @@ instance ( KnownSymbol shortNames
             (symbolVal (Proxy :: Proxy help))
         : getOptDescr (f undefined)
 
-    runCmd f name mbver options nonOptions unrecognized =
-        let flagname = head $
-                       symbolVals (Proxy :: Proxy longNames) ++
-                       [ [c] | c <- symbolVal (Proxy :: Proxy shortNames) ]
-            mbs = lookup flagname options
-        in case (argRead mbs, mbs) of
-            (Nothing, Nothing) ->
-                errorExit name $ "flag must be specified: --" ++ flagname
-            (Nothing, Just s) ->
-                errorExit name $ "bad argument: --" ++ flagname ++ "=" ++ s
-            (Just arg, _) ->
-                runCmd (f $ Flag arg) name mbver options nonOptions unrecognized
+    runCmd f name mbver options nonOptions unrecognized
+       = let flagname = head $ symbolVals (Proxy :: Proxy longNames) ++
+                                 [ [c] | c <- symbolVal (Proxy :: Proxy shortNames) ]
+             mbs = map snd $ filter ((== flagname) . fst) options
+         in case (mbs, argRead mbs) of
+                      ([], Nothing) ->
+                          errorExit name $ "flag must be specified: --" ++ flagname
+                      (s:_, Nothing) ->
+                          errorExit name $ "bad argument: --" ++ flagname ++ "=" ++ s
+                      (_, Just arg) ->
+                          runCmd (f $ Flag arg) name mbver options nonOptions unrecognized
 
 instance ( KnownSymbol placeholder, IsCmd c )
          => IsCmd (Arg placeholder String -> c) where
@@ -246,7 +261,7 @@ instance ( KnownSymbol placeholder, IsCmd c )
         case nonOptions of
             [] -> errorExit name "not enough arguments"
             (opt: rest) ->
-                case argRead (Just opt) of
+                case argRead [opt] of
                     Nothing ->
                         errorExit name $ "bad argument: " ++ opt
                     Just arg ->


### PR DESCRIPTION
1. Support for list types.
2. Change in behavior when the same option is specified multiple times.
3. Better documentation.

## Support for list types
For example, suppose we need `-m` option in `git commit`.
We can give multiple -m options to represent the commit message of multiple lines.
```
$ git commit -m 'Line 1' -m 'Line 2' -m 'Line 3'
```
   This patch changes the signature of `argRead` from `Maybe a -> ...` to `[a] -> ...`. This is needed to allow users to define a user-defined type/parsing function to get a value like `[4, 5, 6]` from the following example, in which multiple values might be extracted from a single argument.

```
$ myapp -t 4,5 -t 6
```
   Note that this is critical for specifying a default value of type `[a]`; we need a way to convert a `String` into multiple values.

## Change in behavior when the same option is specified multiple times
Suppose we have an option `-t` that takes a single integer and a user gives a command line like this:

```
$ myapp -t 1 -t 2
```

Option parsers written in other languages such as GNU getopt often override the former `-t 1` by the latter `-t 2` just because they overwrite values as they process from left to right.
However, `optparse-declarative` worked in the opposite way (`-t 1` took a priority).  I thought it is better to follow the conventional behavior so I changed it.

## Better documentation

I added a document of how to define `argRead` for user-defined types in more details.
I know there is a good user-contributed document in Japanese in Qiita, but adding an English document also helps.
This patch is dependent on "Support for List types."

## A few additional notes

1. I first tried to define `instance (ArgRead a) => ArgRead [a]`, but I found it was annoying due to overlapping instances.
   Especially `ArgRead String` can be considered as `ArgRead [Char]`, which messes things up.
   There must be a workaround for this but it was beyond my Haskell skill. Let me know if you have any good idea to avoid this.
   If you throw away support for older GHC, there might be a way, I guess, but I haven't digged into this.

2. The version number was not changed, so could you change the version number if you accept any code.
   This patch contains a breaking change so probably the next version would be `0.4.0`.

3. I didn't touch `ChangeLog` either.

If you find any problems or have any questions, please let me know.