### PR TITLE
Make types other than String to be IsCmd instances

### DIFF
--- a/example/nonstrargs.hs
+++ b/example/nonstrargs.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE DataKinds #-}
+
+import           Control.Monad.Trans
+import           Options.Declarative
+
+sum' :: Arg "N" Int
+     -> Arg "NS" [Int]
+     -> Cmd "Simple greeting example" ()
+sum' n ns =
+    liftIO $ putStrLn $ show (get n) ++ ", " ++ show (sum $ get ns)
+
+main :: IO ()
+main = run_ sum'


### PR DESCRIPTION
This PR makes types other than `String` which are instances of `ArgRead` to be a part of `IsCmd` instances.

```haskell
foo :: Arg "N" Int    -- Int can be here
    -> Arg "NS" [Int] -- and here
    -> Cmd "Sample" ()
```